### PR TITLE
feat: serve genome browser tracks from database (#59)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-files"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d832782fac6ca7369a70c9ee9a20554623c5e51c76e190ad151780ebea1cf689"
+dependencies = [
+ "actix-http",
+ "actix-service",
+ "actix-utils",
+ "actix-web",
+ "askama_escape",
+ "bitflags",
+ "bytes",
+ "derive_more",
+ "futures-core",
+ "http-range",
+ "log",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "actix-http"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,6 +282,12 @@ checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "askama_escape"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
 
 [[package]]
 name = "autocfg"
@@ -1093,6 +1122,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
+
+[[package]]
 name = "httparse"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1364,6 +1399,16 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -2397,6 +2442,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2461,6 +2515,7 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 name = "varfish-server-worker"
 version = "0.4.0"
 dependencies = [
+ "actix-files",
  "actix-web",
  "anyhow",
  "base16ct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+actix-files = "0.6.2"
 actix-web = "4.3.0"
 anyhow = { version = "1.0.68", features = ["backtrace"] }
 base16ct = "0.1.1"

--- a/src/server/rest.rs
+++ b/src/server/rest.rs
@@ -288,14 +288,19 @@ pub mod actix_server {
 
     #[actix_web::main]
     pub async fn main(args: &Args, dbs: Data<WebServerData>) -> std::io::Result<()> {
+        let tracks_dir = std::path::Path::new(&args.path_db.clone())
+            .join("public")
+            .join("tracks");
+
         HttpServer::new(move || {
-            App::new()
+            let app = App::new()
                 .app_data(dbs.clone())
                 .service(fetch_tads)
                 .service(fetch_pathogenic)
                 .service(fetch_clinvar_sv)
-                .service(fetch_bgdb_records)
-                .wrap(Logger::default())
+                .service(fetch_bgdb_records);
+            let app = app.service(actix_files::Files::new("/public/tracks", &tracks_dir));
+            app.wrap(Logger::default())
         })
         .bind((args.listen_host.as_str(), args.listen_port))?
         .run()


### PR DESCRIPTION
If the path "public/tracks" exists in the database then it will be served from the URL "/public/tracks".